### PR TITLE
add contents section and split the setup tasks into sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,19 @@
 # Testing Database Queries with Tape
 
+## Contents
+<!-- generated using markdown-toc
+$ npx markdown-toc README.md
+-->
+* [Learning Objectives](#learning-objectives)
+* [Why do we need a test database?](#why-do-we-need-a-test-database)
+* [Let's go!](#lets-go)
+  + [1. Create a test database](#1-create-a-test-database)
+  + [2. Configure the `db_connection` file](#2-configure-the-db_connection-file)
+  + [3. Create the test script](#3-create-the-test-script)
+  + [4. Turn the db build script into a reusable function](#4-turn-the-db-build-script-into-a-reusable-function)
+  + [5. Write tests!](#5-write-tests)
+* [Additional Info](#additional-info)
+
 ## Learning Objectives
 
 To be able to:
@@ -11,17 +25,14 @@ To be able to:
 
 In this workshop we will create a test database to run our tests on, which is separate from our production database. We use a test database so that we can add, delete, or update data in our tests without affecting our production database.
 
-## Getting Started
+## Let's go!
 
 * Clone this repo
 * Navigate to it in your terminal and run `npm i`
 
 We are going to start by creating a test database for us to run our tests on.
 
-1. Create tests folder:
-
-* Create `tests` folder in the root folder.
-* Create file `test.js` in `tests`.
+### 1. Create a test database
 
 2. Set up your test database:
 
@@ -60,6 +71,8 @@ values in square brackets to the values you defined in the steps above):
   test database with data: `\i [full_path_to_db_build.sql]` (To easily copy a
   file's full path right click on it in atom and click on "Copy Full Path")
 
+### 2. Configure the `db_connection` file
+
 * Now we have to specify in which cases we use the real database and in which
   cases we use the test one. To do that we have to set up a `NODE_ENV` variable:
 
@@ -87,14 +100,23 @@ if (!DB_URL) throw new Error("Enviroment variable DB_URL must be set");
 const params = url.parse(DB_URL);
 ```
 
-The last thing to do here is to add a script in `package.json` to run your
+### 3. Create the test script
+
+1. Create a tests folder:
+
+* Create a `tests` folder in the root folder.
+* Create file `test.js` in `tests`.
+
+Then add a script in `package.json` to run your
 tests: `"test": "NODE_ENV=test node tests/test.js",` When you want to run your
-tests run `npm run test` in your terminal.
+tests, run `npm run test` in your terminal.
 
 * We are almost ready to write the tests. An important idea to keep in mind is
   that before running the tests we need to make sure that our test database is
   at its default state. That's why before running every single test we have to
   rerun the script from `db_build.js` to restart the database.
+
+### 4. Turn the db build script into a reusable function
 
 * To make sure that any tests will be executed only after the database has been
   restarted we need the `runDbBuild` function in `db_build.js` to be a callback
@@ -109,9 +131,7 @@ const runDbBuild = cb => {
 };
 ```
 
-#### Now you are ready to write some tests!
-
-## Tests
+### 5. Write tests!
 
 * In your `tests.js` require tape, runDbBuild function and queries that you are
   going to test:
@@ -145,7 +165,7 @@ tape('what you are going to test', (t)=> {
 
 * Now it's time to experiment with writing your tests! :)
 
-## _FYI(Additional Info)_
+## Additional Info
 
 On larger projects we may want to have a `test_db_build.sql` so that we can have a range of fake data in our test database to test on. To do this our `db_build.js` will need to check which sql script it needs to run.
 


### PR DESCRIPTION

This PR makes the README clearer/more navigable for students, and adding sections makes it more manageable to edit/improve the sections individually.

- splits the `getting started` section into separate parts (and renames it to `let's go!`). 
- I haven't changed any of the content, only one small section (creating the `test.js` file) was moved.
- also adds contents section with these new sections in it.
